### PR TITLE
Avoid trying to load classes from the default package (fixes #21)

### DIFF
--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -125,11 +125,14 @@ public class ModuleClassLoader extends ClassLoader {
         synchronized (getClassLoadingLock(name)) {
             var c = findLoadedClass(name);
             if (c == null) {
-                final var pname = name.substring(0, name.lastIndexOf('.'));
-                if (this.packageLookup.containsKey(pname)) {
-                    c = findClass(this.packageLookup.get(pname).name(), name);
-                } else {
-                    c = this.parentLoaders.getOrDefault(pname, fallbackClassLoader).loadClass(name);
+                var index = name.lastIndexOf('.');
+                if (index >= 0) {
+                    final var pname = name.substring(0, index);
+                    if (this.packageLookup.containsKey(pname)) {
+                        c = findClass(this.packageLookup.get(pname).name(), name);
+                    } else {
+                        c = this.parentLoaders.getOrDefault(pname, fallbackClassLoader).loadClass(name);
+                    }
                 }
             }
             if (c == null) throw new ClassNotFoundException(name);


### PR DESCRIPTION
As described in #21, the `ModuleClassLoader` throws an unexpected `StringIndexOutOfBoundsException` exception when trying to load a class from the default package.  

This PR adds an `if` statement to ignore package-less classes, restoring expected behavior throwing a `ClassNotFoundException`.