### PR TITLE
Fix JarMetadata maven path detection for incomplete paths

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -57,17 +57,20 @@ public interface JarMetadata {
         if (versionMaybe != null)
         {
             Path artifactMaybe = versionMaybe.getParent();
-            if (artifactMaybe != null && path.getFileName().toString().startsWith(artifactMaybe.getFileName().toString() + "-" + versionMaybe.getFileName().toString()))
+            if (artifactMaybe != null)
             {
-                var name = artifactMaybe.getFileName().toString();
-                var ver = versionMaybe.getFileName().toString();
-                var mat = MODULE_VERSION.matcher(ver);
-                if (mat.find()) {
-                    ver = ModuleDescriptor.Version.parse(ver.substring(mat.start())).toString();
-                    return new SimpleJarMetadata(cleanModuleName(name), ver, pkgs, providers);
-                } else {
-                    return new SimpleJarMetadata(cleanModuleName(name), null, pkgs, providers);
-                }
+                Path artifactNameMaybe = artifactMaybe.getFileName();
+                if (artifactNameMaybe != null && path.getFileName().toString().startsWith(artifactNameMaybe + "-" + versionMaybe.getFileName().toString())) {
+                    var name = artifactMaybe.getFileName().toString();
+                    var ver = versionMaybe.getFileName().toString();
+                    var mat = MODULE_VERSION.matcher(ver);
+                    if (mat.find()) {
+                        ver = ModuleDescriptor.Version.parse(ver.substring(mat.start())).toString();
+                        return new SimpleJarMetadata(cleanModuleName(name), ver, pkgs, providers);
+                    } else {
+                        return new SimpleJarMetadata(cleanModuleName(name), null, pkgs, providers);
+                    }
+                }   
             }
         }
 

--- a/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
+++ b/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
@@ -18,6 +18,15 @@ public class TestMetadata
         Assertions.assertEquals("_new._protected._class._1._16._5", meta.name());
         Assertions.assertEquals("1.1_mapped_official_1.17.1", meta.version());
     }
+    
+    @Test
+    void testRootStart()
+    {
+        var path = Paths.get("/instance/mods/1life-1.5.jar");
+        var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
+        Assertions.assertEquals("_1life", meta.name());
+        Assertions.assertEquals("1.5", meta.version());
+    }
 
     @Test
     void testNumberStart()


### PR DESCRIPTION
### The Issue
`SimpleJarMetadata#fromFileName` throws a NPE when the jar path is exactly one folder from its root (#19)

### The Solution
Adding an additional `if` statement to ensure the artifact path's file name isn't null seems to be the most optimal solution.
I've also tried comparing `artifactMaybe` with its root, but that might be null in some cases, like [`TestMetadata#testNumberStart`](https://github.com/McModLauncher/securejarhandler/blob/375c6b5e637056fd5dc54dc43d834eb8ed943d40/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java#L25).

Comes with a corresponding unit test for this use case.