### PR TITLE
Filter modules by reference type, allows launching without BSL

### DIFF
--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -48,6 +48,8 @@ public class ModuleClassLoader extends ClassLoader {
         for (var rm : configuration.modules()) {
             for (var other : rm.reads()) {
                 Supplier<ClassLoader> findClassLoader = ()->{
+                    // Loading a class requires its module to be part of resolvedRoots
+                    // If it's not, we delegate loading to its module's classloader
                     if (!this.resolvedRoots.containsKey(other.name())) {
                         return parentLayers.stream()
                                 .filter(l -> l.configuration() == other.configuration())

--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -32,22 +32,23 @@ public class ModuleClassLoader extends ClassLoader {
     public ModuleClassLoader(final String name, final Configuration configuration, final List<ModuleLayer> parentLayers) {
         super(name, null);
         this.configuration = configuration;
-        record JarRef(ResolvedModule m, JarModuleFinder.JarModuleReference ref) {}
         this.resolvedRoots = configuration.modules().stream()
-                .filter(m->m.reference() instanceof JarModuleFinder.JarModuleReference)
-                .map(m->new JarRef(m, (JarModuleFinder.JarModuleReference)m.reference()))
-                .collect(Collectors.toMap(r->r.m().name(), JarRef::ref));
+                .map(ResolvedModule::reference)
+                .filter(JarModuleFinder.JarModuleReference.class::isInstance)
+                .collect(Collectors.toMap(r -> r.descriptor().name(), r -> (JarModuleFinder.JarModuleReference) r));
 
         this.packageLookup = new HashMap<>();
         for (var mod : this.configuration.modules()) {
-            mod.reference().descriptor().packages().forEach(pk->this.packageLookup.put(pk, mod));
+            if (this.resolvedRoots.containsKey(mod.name())) {
+                mod.reference().descriptor().packages().forEach(pk->this.packageLookup.put(pk, mod));
+            }
         }
 
         this.parentLoaders = new HashMap<>();
         for (var rm : configuration.modules()) {
             for (var other : rm.reads()) {
                 Supplier<ClassLoader> findClassLoader = ()->{
-                    if (other.configuration() != configuration) {
+                    if (!this.resolvedRoots.containsKey(other.name())) {
                         return parentLayers.stream()
                                 .filter(l -> l.configuration() == other.configuration())
                                 .flatMap(layer->Optional.ofNullable(layer.findLoader(other.name())).stream())


### PR DESCRIPTION
### Launching without BootstrapLauncher
This PR allows ModuleClassLoader to initialize from a single configuration that contains user-defined and/or system modules, supporting non-BSL launch.

### The issue
Currently, when loading classes, ModuleClassLoader assumes it can find a `resolvedRoots` entry for any package contained in `packageLookup`. Therefore if we pass in the java boot configuration, `resolvedRoots` will remain empty while `packageLookup` is filled with java system packages.
Loading arbitrary classes will then lead to [attempting to load](https://github.com/McModLauncher/securejarhandler/blob/41ecce081706f0596abeab8c060fecfb5deb4693/src/main/java/cpw/mods/cl/ModuleClassLoader.java#L131) java classes from this classloader, which will be later unable to [get the module root](https://github.com/McModLauncher/securejarhandler/blob/41ecce081706f0596abeab8c060fecfb5deb4693/src/main/java/cpw/mods/cl/ModuleClassLoader.java#L113) for the class package and throw a `NullPointerException`.

### Expected behavior
Avoid loading classes from modules that aren't contained in `resolvedRoots`.

### Filtering modules
When resolving roots, ModuleClassLoader [filters](https://github.com/Su5eD/securejarhandler/blob/c00af4b648fbc1be6133b6963b72f27768ccb59c/src/main/java/cpw/mods/cl/ModuleClassLoader.java#L37) modules by their reference type to exclude system modules.
Now, we'll limit [`packageLookup`](https://github.com/Su5eD/securejarhandler/blob/c00af4b648fbc1be6133b6963b72f27768ccb59c/src/main/java/cpw/mods/cl/ModuleClassLoader.java#L42) to modules contained in `resolvedRoots`, and [exclude](https://github.com/Su5eD/securejarhandler/blob/c00af4b648fbc1be6133b6963b72f27768ccb59c/src/main/java/cpw/mods/cl/ModuleClassLoader.java#L51) the others from being loaded by ModuleClassLoader.