### PR TITLE
Fix hierarchy computation of boot layer classes

### DIFF
--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -238,7 +238,7 @@ public class ModuleClassLoader extends ClassLoader {
                 bytes = loadFromModule(classNameToModuleName(name), (reader, ref)->this.getClassBytes(reader, ref, name));
             } else {
                 var cname = name.replace('.','/')+".class";
-                try (var is = this.parentLoaders.getOrDefault(pname, ClassLoader.getPlatformClassLoader()).getResourceAsStream(cname)) {
+                try (var is = this.parentLoaders.getOrDefault(pname, ClassLoader.getSystemClassLoader()).getResourceAsStream(cname)) {
                     if (is != null)
                         bytes = is.readAllBytes();
                 }

--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -230,21 +230,22 @@ public class ModuleClassLoader extends ClassLoader {
         }
     }
 
-    protected byte[] getMaybeTransformedClassBytes(final String name, final String context) {
+    protected byte[] getMaybeTransformedClassBytes(final String name, final String context) throws ClassNotFoundException {
         byte[] bytes = new byte[0];
         try {
             final var pname = name.substring(0, name.lastIndexOf('.'));
             if (this.packageLookup.containsKey(pname)) {
                 bytes = loadFromModule(classNameToModuleName(name), (reader, ref)->this.getClassBytes(reader, ref, name));
-            } else {
+            } else if (this.parentLoaders.containsKey(pname)) {
                 var cname = name.replace('.','/')+".class";
-                try (var is = this.parentLoaders.getOrDefault(pname, ClassLoader.getSystemClassLoader()).getResourceAsStream(cname)) {
+                try (var is = this.parentLoaders.get(pname).getResourceAsStream(cname)) {
                     if (is != null)
                         bytes = is.readAllBytes();
                 }
             }
         } catch (IOException ignored) {
         }
+        if (bytes.length == 0) throw new ClassNotFoundException(name);
         return maybeTransformClassBytes(bytes, name, context);
     }
 


### PR DESCRIPTION
#### The issue
As reported in #27, ModuleClassLoader fails to read bytes of libraries on the java boot module layer used in transformers. This happens because it's trying to find resources on the PlatformClassLoader instead of the AppClassLoader.
See [here](https://github.com/McModLauncher/securejarhandler/issues/27#issuecomment-998171355) for a full explanation of the issue by @sciwhiz12.

#### The solution
Quote from sciwhiz's explanation:
> Therefore, the solution is that the above error be corrected by changing the use of `ClassLoader.getPlatformClassLoader()` to `ClassLoader.getSystemClassLoader()` instead, so the resolution of class bytes for ASM, SJH, and BSL (or any other class whose module is in the ignore list configured in BSL and exists on the application class loader) works as expected.