### PR TITLE
Allow registering additional packages to modules

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 public interface JarMetadata {
     String name();
     String version();
-    ModuleDescriptor descriptor();
+    ModuleDescriptor descriptor(Set<String> additionalPackages);
     // ALL from jdk.internal.module.ModulePath.java
     Pattern DASH_VERSION = Pattern.compile("-([.\\d]+)");
     Pattern NON_ALPHANUM = Pattern.compile("[^A-Za-z0-9]");

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -43,8 +43,8 @@ public class Jar implements SecureJar {
         return this.filesystem.getRootDirectories().iterator().next().toUri();
     }
 
-    public ModuleDescriptor computeDescriptor() {
-        return metadata.descriptor();
+    public ModuleDescriptor computeDescriptor(Set<String> additionalPackages) {
+        return metadata.descriptor(additionalPackages);
     }
 
     @Override
@@ -67,7 +67,6 @@ public class Jar implements SecureJar {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public Jar(final Supplier<Manifest> defaultManifest, final Function<SecureJar, JarMetadata> metadataFunction, final BiPredicate<String, String> pathfilter, final Path... paths) {
         var validPaths = Arrays.stream(paths).filter(Files::exists).toArray(Path[]::new);
         if (validPaths.length == 0)

--- a/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
@@ -9,11 +9,12 @@ import java.util.Set;
 
 public record SimpleJarMetadata(String name, String version, Set<String> pkgs, List<SecureJar.Provider> providers) implements JarMetadata {
     @Override
-    public ModuleDescriptor descriptor() {
+    public ModuleDescriptor descriptor(Set<String> additionalPackages) {
         var bld = ModuleDescriptor.newAutomaticModule(name());
         if (version()!=null)
             bld.version(version());
         bld.packages(pkgs());
+        bld.packages(additionalPackages);
         providers.stream().filter(p->!p.providers().isEmpty()).forEach(p->bld.provides(p.serviceName(), p.providers()));
         return bld.build();
     }


### PR DESCRIPTION
This PR adds required backend code allowing Modlauncher to register additional packages to modules for the purpose of class generation.

## The Solution

Add a simple API that allows registering additional packages to modules when computing module descriptors.
Packages can be provided to `JarModuleFinder` in the form of a `Map<String, Set<String>>`, containing `module name` -> `packages` pairs.

When creating module references, `JarModuleFinder` will query this map for packages to add to the module. If any are found, they will be passed into `JarMetadata#descriptor` and added to the module descriptor.