### PR TITLE
Avoid using Pattern and Streams in UnionPath init

### DIFF
--- a/src/test/java/cpw/mods/niofs/union/TestUnionPath.java
+++ b/src/test/java/cpw/mods/niofs/union/TestUnionPath.java
@@ -40,9 +40,11 @@ public class TestUnionPath {
         var abs123 = fs.getPath("/one/two/three");
         var abs1223 = fs.getPath("/one/two/./three");
         var abs12up3 = fs.getPath("/one/two/../three");
+        var abs12up3otherslash = fs.getPath("/one/two/..\\three");
         var abs13 = fs.getPath("/one/three");
         var abs13slash = fs.getPath("/one/three/");
         var abs1slash3 = fs.getPath("/one//three");
+        var abs1otherslash3 = fs.getPath("/one\\/three");
         var absUpUp1 = fs.getPath("/../../one");
         var absUpUp123 = fs.getPath("/../../one/two/three");
         
@@ -51,6 +53,8 @@ public class TestUnionPath {
         assertEquals(rel13, rel1slash3);
         assertEquals(abs13, abs13slash);
         assertEquals(abs13, abs1slash3);
+        assertEquals(abs13, abs1otherslash3);
+        assertEquals(abs12up3, abs12up3otherslash);
         // Not filtering out empty elements for joining will cause this to fail
         assertFalse(fs.getPath("", "one", "two").isAbsolute());
         


### PR DESCRIPTION
Speeds up creation of UnionPath significantly. Reduces time spend in testJarFileExists from 7585 to 2777, other tests like testCommonPathUtilities see improvements as well

Benchmark results on my Windows machine:
Before:
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel","avgt",1,2,"129528,239577",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities","avgt",1,2,"2310,161589",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream","avgt",1,2,"91979,226766",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir","avgt",1,2,"206381,228068",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists","avgt",1,2,"7585,715661",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists","avgt",1,2,"7958,457813",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists","avgt",1,2,"120012,356044",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists","avgt",1,2,"81349,792250",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes","avgt",1,2,"7883,473942",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes:·stack","avgt",1,1,NaN,NaN,"---"

After:
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel","avgt",1,2,"120842,178430",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testByteChannel:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities","avgt",1,2,"386,721520",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testCommonPathUtilities:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream","avgt",1,2,"84422,986678",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStream:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir","avgt",1,2,"212206,019691",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testDirectoryStreamDir:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists","avgt",1,2,"2777,622614",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists","avgt",1,2,"3192,212457",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testJarFileNotExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists","avgt",1,2,"116069,613764",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists","avgt",1,2,"78360,375172",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testNativeFileNotExists:·stack","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes","avgt",1,2,"2930,187392",NaN,"ns/op"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes:·jfr","avgt",1,1,NaN,NaN,"---"
"cpw.mods.niofs.union.benchmarks.UnionFileSystemBenchmark.testReadAttributes:·stack","avgt",1,1,NaN,NaN,"---"