### PR TITLE
Make it possible to compute JarMetadata from non-jar sources

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -77,7 +77,7 @@ public interface JarMetadata {
         // fallback parsing
         var fn = path.getFileName().toString();     
         var lastDot = fn.lastIndexOf('.');
-        if(lastDot > 0) {
+        if (lastDot > 0) {
             fn = fn.substring(0, lastDot); // strip extension if possible
         }
        

--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -75,8 +75,12 @@ public interface JarMetadata {
         }
 
         // fallback parsing
-        var fn = path.getFileName().toString();
-        fn = fn.contains(".") ? fn.substring(0, fn.lastIndexOf('.')) : fn; // strip extension if possible
+        var fn = path.getFileName().toString();     
+        var lastDot = fn.lastIndexOf('.');
+        if(lastDot > 0) {
+            fn = fn.substring(0, lastDot); // strip extension if possible
+        }
+       
         var mat = DASH_VERSION.matcher(fn);
         if (mat.find()) {
             var ver = ModuleDescriptor.Version.parse(fn.substring(mat.start() + 1)).toString();

--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -76,7 +76,7 @@ public interface JarMetadata {
 
         // fallback parsing
         var fn = path.getFileName().toString();
-        fn = fn.substring(0, fn.length()-4); // no .jar extension
+        fn = fn.contains(".") ? fn.substring(0, fn.lastIndexOf('.')) : fn; // strip extension if possible
         var mat = DASH_VERSION.matcher(fn);
         if (mat.find()) {
             var ver = ModuleDescriptor.Version.parse(fn.substring(mat.start() + 1)).toString();


### PR DESCRIPTION
## Preamble
This is an ad-hoc fix for an issue i have with using sjh in combination with bsl.

## The issue
As I use SJH in an ide where the classpath just points to the build output folder, my resources are ignored by BSL.

## The reason
SJH falls back to just blindly stripping the last 4 chars of a file name if it does not conform to maven-name standards. So if you parse a file without a file extension (for example a directory) or a file extension shorter or longer than 4 chars the name gets scrambled.

Even worse: if the path name only is 4 letters long (e.g a main resources output folder) the resulting name is actually empty, and a name shorter than 4 jars will result in an IllegalArgumentException thrown by String::substring.

## The solution
There is a simple solution to this issue: just don't strip the file extension if there is none and don't assume the file extension to always be 3 chars long.