### PR TITLE
Reintroduce removed accessors from the V1 API

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -32,6 +32,12 @@ public interface SecureJar {
         CodeSigner[] verifyAndGetSigners(String cname, byte[] bytes);
     }
 
+    @Deprecated
+    Manifest getManifest();
+
+    @Deprecated
+    Optional<URI> findFile(String name);
+
     ModuleDataProvider moduleDataProvider();
 
     Path getPrimaryPath();

--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -33,10 +33,14 @@ public interface SecureJar {
     }
 
     @Deprecated
-    Manifest getManifest();
+    default Manifest getManifest() {
+        return this.moduleDataProvider().getManifest();
+    }
 
     @Deprecated
-    Optional<URI> findFile(String name);
+    default Optional<URI> findFile(String name) {
+        return this.moduleDataProvider().findFile(name);
+    }
 
     ModuleDataProvider moduleDataProvider();
 

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -61,6 +61,7 @@ public class Jar implements SecureJar {
         return filesystem.getPrimaryPath();
     }
 
+    @Override
     public Optional<URI> findFile(final String name) {
         var rel = filesystem.getPath(name);
         if (this.nameOverrides.containsKey(rel)) {
@@ -143,6 +144,7 @@ public class Jar implements SecureJar {
         this.metadata = metadataFunction.apply(this);
     }
 
+    @Override
     public Manifest getManifest() {
         return manifest;
     }


### PR DESCRIPTION
Reintroduce the API methods removed in the V2 release as deprecated, to notify the users not to use those.
The motive behind this PR is to backport the Jar-in-Jar fixes from 1.19 (namely mixins and server fixes) to 1.18.

The easiest way I found to do this is to update SJH, JIJ and BootstrapLauncher to their latest respective versions. That cannot be done currently since moving from SJH from version 1 to version 2 would be a breaking change.
The changes proposed here aim to make code compiled against version 1 work against version 2, making it possible to upgrade forge without causing binary breaking changes.