### PR TITLE
Speedup jar package scanning

### DIFF
--- a/src/main/java/cpw/mods/cl/JarModuleFinder.java
+++ b/src/main/java/cpw/mods/cl/JarModuleFinder.java
@@ -25,6 +25,9 @@ public class JarModuleFinder implements ModuleFinder {
 
         record ref(SecureJar.ModuleDataProvider jar, ModuleReference ref) {}
         this.moduleReferenceMap = Arrays.stream(jars)
+                // Computing the module descriptor can be slow so do it in parallel!
+                // Jars are not thread safe internally but they are independent, so this is safe.
+                .parallel()
                 .map(jar->new ref(jar.moduleDataProvider(), new JarModuleReference(jar.moduleDataProvider())))
                 .collect(Collectors.toMap(r->r.jar.name(), r->r.ref, (r1, r2)->r1));
 

--- a/src/main/java/cpw/mods/cl/JarModuleFinder.java
+++ b/src/main/java/cpw/mods/cl/JarModuleFinder.java
@@ -21,8 +21,6 @@ public class JarModuleFinder implements ModuleFinder {
     private final Map<String, ModuleReference> moduleReferenceMap;
 
     JarModuleFinder(final SecureJar... jars) {
-        long startTime = System.nanoTime();
-
         record ref(SecureJar.ModuleDataProvider jar, ModuleReference ref) {}
         this.moduleReferenceMap = Arrays.stream(jars)
                 // Computing the module descriptor can be slow so do it in parallel!
@@ -30,9 +28,6 @@ public class JarModuleFinder implements ModuleFinder {
                 .parallel()
                 .map(jar->new ref(jar.moduleDataProvider(), new JarModuleReference(jar.moduleDataProvider())))
                 .collect(Collectors.toMap(r->r.jar.name(), r->r.ref, (r1, r2)->r1));
-
-        long endTime = System.nanoTime();
-        System.out.println("JarModuleFinder: took " + (endTime - startTime) / 1000000 + "ms to build module references");
     }
 
     @Override

--- a/src/main/java/cpw/mods/cl/JarModuleFinder.java
+++ b/src/main/java/cpw/mods/cl/JarModuleFinder.java
@@ -21,10 +21,15 @@ public class JarModuleFinder implements ModuleFinder {
     private final Map<String, ModuleReference> moduleReferenceMap;
 
     JarModuleFinder(final SecureJar... jars) {
+        long startTime = System.nanoTime();
+
         record ref(SecureJar.ModuleDataProvider jar, ModuleReference ref) {}
         this.moduleReferenceMap = Arrays.stream(jars)
                 .map(jar->new ref(jar.moduleDataProvider(), new JarModuleReference(jar.moduleDataProvider())))
                 .collect(Collectors.toMap(r->r.jar.name(), r->r.ref, (r1, r2)->r1));
+
+        long endTime = System.nanoTime();
+        System.out.println("JarModuleFinder: took " + (endTime - startTime) / 1000000 + "ms to build module references");
     }
 
     @Override

--- a/src/main/java/cpw/mods/jarhandling/SecureJarRuntime.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJarRuntime.java
@@ -1,0 +1,9 @@
+package cpw.mods.jarhandling;
+
+import java.util.Set;
+
+public interface SecureJarRuntime {
+    default Set<String> ignoredRootPackages() {
+        return Set.of("META-INF");
+    }
+}

--- a/src/main/java/cpw/mods/jarhandling/SecureJarRuntime.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJarRuntime.java
@@ -3,6 +3,9 @@ package cpw.mods.jarhandling;
 import java.util.Set;
 
 public interface SecureJarRuntime {
+    /**
+     * Return the set of top-level folders in the JARs that should not be searched for class files.
+     */
     default Set<String> ignoredRootPackages() {
         return Set.of("META-INF");
     }

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -231,7 +231,7 @@ public class Jar implements SecureJar {
     @Override
     public Set<String> getPackages() {
         if (this.packages == null) {
-            this.packages = new HashSet<>();
+            Set<String> packages = new HashSet<>();
             try {
                 Files.walkFileTree(this.filesystem.getRoot(), new SimpleFileVisitor<>() {
                     @Override
@@ -253,6 +253,7 @@ public class Jar implements SecureJar {
                         return FileVisitResult.CONTINUE;
                     }
                 });
+                this.packages = packages;
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/src/main/java/cpw/mods/jarhandling/impl/SecureJarEnvironment.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/SecureJarEnvironment.java
@@ -1,0 +1,30 @@
+package cpw.mods.jarhandling.impl;
+
+import cpw.mods.jarhandling.SecureJarRuntime;
+
+import java.util.ServiceLoader;
+import java.util.Set;
+
+class SecureJarEnvironment {
+    static final SecureJarRuntime runtime = findRuntime();
+    static final Set<String> ignoredRootPackages = findIgnoredRootPackages();
+
+    private static SecureJarRuntime findRuntime() {
+        return ServiceLoader.load(SecureJarRuntime.class).findFirst().orElse(new SecureJarRuntime() {});
+    }
+
+    private static Set<String> findIgnoredRootPackages() {
+        var packages = runtime.ignoredRootPackages();
+        // Validate root packages
+        for (var pkg : packages) {
+            if (pkg.contains(".") || pkg.contains("/")) {
+                throw new IllegalArgumentException("Invalid root package: " + pkg);
+            }
+        }
+        return packages;
+    }
+
+    public static boolean isIgnoredRootPackage(String pkg) {
+        return ignoredRootPackages.contains(pkg);
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -14,4 +14,5 @@ module cpw.mods.securejarhandler {
     provides java.nio.file.spi.FileSystemProvider with UnionFileSystemProvider;
     uses cpw.mods.cl.ModularURLHandler.IURLProvider;
     provides ModularURLHandler.IURLProvider with UnionURLStreamHandler;
+    uses cpw.mods.jarhandling.SecureJarRuntime;
 }


### PR DESCRIPTION
I noted that building the module references was quite slow on the FC pack, so I propose these two simple changes:
- Some mods have a ton of assets and it takes forever to scan them... Chipped alone takes 2 seconds. So I added the infrastructure to skip some folders in the JARs. With https://github.com/neoforged/FancyModLoader/pull/14, this skips scanning the `assets` and `data` mod files for JARs. 
- Build `ModuleReference`s in parallel because why not.

Performance numbers on the FC pack (single run per line so not super precise but VisualVM confirms the observations):
```
Baseline: 4292ms
Added root package filter without FML support: 4207ms
Added root package filter with FML support: 1136ms
Additionally make jar resolution parallel: 340ms
```