### PR TITLE
Remove the `notExistingPath` check and use proper lazy streams

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -385,7 +385,7 @@ public class UnionFileSystem extends FileSystem {
             closeables.add(ds);
             stream = Stream.concat(stream, StreamSupport.stream(ds.spliterator(), false)
                     .filter(p -> testFilter(p, bp))
-                    .map(other -> StreamSupport.stream(Spliterators.spliteratorUnknownSize((isSimple ? other : bp.relativize(other)).iterator(), Spliterator.ORDERED), false)
+                    .map(other -> StreamSupport.stream((isSimple ? other : bp.relativize(other)).spliterator(), false)
                             .map(Path::getFileName).map(Path::toString).toArray(String[]::new))
                     .map(this::fastPath));
         }

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -397,8 +397,20 @@ public class UnionFileSystem extends FileSystem {
 
             @Override
             public void close() throws IOException {
+                List<IOException> exceptions = new ArrayList<>();
+
                 for (Closeable closeable : closeables) {
-                    closeable.close();
+                    try {
+                        closeable.close();
+                    } catch (IOException e) {
+                        exceptions.add(e);
+                    }
+                }
+
+                if (!exceptions.isEmpty()) {
+                    IOException aggregate = new IOException("Failed to close some streams in UnionFileSystem.newDirStream");
+                    exceptions.forEach(aggregate::addSuppressed);
+                    throw aggregate;
                 }
             }
         };

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -389,7 +389,7 @@ public class UnionFileSystem extends FileSystem {
                             .map(Path::getFileName).map(Path::toString).toArray(String[]::new))
                     .map(this::fastPath));
         }
-        final Stream<Path> realStream = stream;
+        final Stream<Path> realStream = stream.distinct();
         return new DirectoryStream<>() {
             @Override
             public Iterator<Path> iterator() {

--- a/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
+++ b/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
@@ -1,7 +1,6 @@
 package cpw.mods.niofs.union;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -13,14 +12,22 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUnionFS {
     private static final UnionFileSystemProvider UFSP = (UnionFileSystemProvider) FileSystemProvider.installedProviders().stream().filter(fsp->fsp.getScheme().equals("union")).findFirst().orElseThrow(()->new IllegalStateException("Couldn't find UnionFileSystemProvider"));
@@ -252,15 +259,35 @@ public class TestUnionFS {
         final var fileSystem = UFSP.newFileSystem(jar1, Map.of("additional", List.of(jar2, jar3)));
         var root = fileSystem.getPath("/");
         try (var dirStream = Files.newDirectoryStream(root)) {
-            final AtomicInteger amount = new AtomicInteger();
+            final List<String> foundFiles = new ArrayList<>();
             assertAll(
-                    StreamSupport.stream(dirStream.spliterator(), false).<Executable>map(p-> ()-> {
-                        if (!Files.exists(p)) {
-                            throw new FileNotFoundException(p.toString());
-                        }
-                    }).peek(it -> amount.incrementAndGet())
+                    StreamSupport.stream(dirStream.spliterator(), false)
+                        .peek(path -> foundFiles.add(path.toString()))
+                        .map(p-> ()-> {
+                            if (!Files.exists(p)) {
+                                throw new FileNotFoundException(p.toString());
+                            }
+                        })
             );
-            assert amount.get() > 10;
+            assertEquals(foundFiles, List.of(
+                    "log4j2.xml",
+                    "module-info.class",
+                    "cpw",
+                    "META-INF",
+                    "LICENSE.txt",
+                    "CREDITS.txt",
+                    "url.png",
+                    "pack.mcmeta",
+                    "mcplogo.png",
+                    "forge_logo.png",
+                    "forge.srg",
+                    "forge.sas",
+                    "forge.exc",
+                    "data",
+                    "coremods",
+                    "assets",
+                    "net"
+            ));
         }
     }
     @Test


### PR DESCRIPTION
The `!= notExistingPath` doesn't do anything, and the `newDirStream` method would accumulate the results in a list, which is not efficient for dir streams that early-exit. Streams are meant to be lazy.