### PR TITLE
Fix UnionPath existence checks with nested union file systems

### DIFF
--- a/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
+++ b/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
@@ -202,6 +202,8 @@ public class TestUnionFS {
         var npath = Paths.get(uri);
         var input = assertDoesNotThrow(() -> Files.newInputStream(npath));
         var data = assertDoesNotThrow(() -> input.readAllBytes());
+
+        assertFalse(Files.exists(outer.getPath("definitely", "does", "not", "exist")));
     }
 
     @Test


### PR DESCRIPTION
Fixes `Files.exists` always returning true for layered/nested UnionFileSystems. The bug happens because of a missing `else` branch in `checkAccess` for non-default and non-zip file systems.

Added a test to reproduce the issue, and consolidated the fs-specific code to avoid such issues in the future.