### PR TITLE
Add lastModified&contentLength to SJH URLConnections

### DIFF
--- a/src/main/java/cpw/mods/cl/ModularURLHandler.java
+++ b/src/main/java/cpw/mods/cl/ModularURLHandler.java
@@ -67,9 +67,35 @@ public class ModularURLHandler implements URLStreamHandlerFactory {
                 throw e.getCause();
             }
         }
+
+        @Override
+        public int getContentLength() {
+            var length = getContentLengthLong();
+            if (length < 0 || length > Integer.MAX_VALUE) {
+                return -1;
+            }
+            return (int) length;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return provider.getContentLength(url);
+        }
+
+        @Override
+        public long getLastModified() {
+            return provider.getLastModified(url);
+        }
+
     }
     public interface IURLProvider {
         String protocol();
         Function<URL, InputStream> inputStreamFunction();
+        default long getLastModified(URL url) {
+            return 0;
+        }
+        default long getContentLength(URL url) {
+            return -1;
+        }
     }
 }

--- a/src/main/java/cpw/mods/cl/UnionURLStreamHandler.java
+++ b/src/main/java/cpw/mods/cl/UnionURLStreamHandler.java
@@ -33,4 +33,34 @@ public class UnionURLStreamHandler implements ModularURLHandler.IURLProvider {
 
         };
     }
+
+    @Override
+    public long getLastModified(URL u) {
+        try {
+            if (Paths.get(u.toURI()) instanceof UnionPath upath) {
+                return Files.getLastModifiedTime(upath).toMillis();
+            } else {
+                throw new IllegalArgumentException("Invalid Path "+u.toURI()+" at UnionURLStreamHandler");
+            }
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public long getContentLength(URL u) {
+        try {
+            if (Paths.get(u.toURI()) instanceof UnionPath upath) {
+                return Files.size(upath);
+            } else {
+                throw new IllegalArgumentException("Invalid Path "+u.toURI()+" at UnionURLStreamHandler");
+            }
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/src/main/java/cpw/mods/cl/UnionURLStreamHandler.java
+++ b/src/main/java/cpw/mods/cl/UnionURLStreamHandler.java
@@ -37,11 +37,7 @@ public class UnionURLStreamHandler implements ModularURLHandler.IURLProvider {
     @Override
     public long getLastModified(URL u) {
         try {
-            if (Paths.get(u.toURI()) instanceof UnionPath upath) {
-                return Files.getLastModifiedTime(upath).toMillis();
-            } else {
-                throw new IllegalArgumentException("Invalid Path "+u.toURI()+" at UnionURLStreamHandler");
-            }
+            return Files.getLastModifiedTime(Paths.get(u.toURI())).toMillis();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
@@ -52,11 +48,7 @@ public class UnionURLStreamHandler implements ModularURLHandler.IURLProvider {
     @Override
     public long getContentLength(URL u) {
         try {
-            if (Paths.get(u.toURI()) instanceof UnionPath upath) {
-                return Files.size(upath);
-            } else {
-                throw new IllegalArgumentException("Invalid Path "+u.toURI()+" at UnionURLStreamHandler");
-            }
+            return Files.size(Paths.get(u.toURI()));
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {


### PR DESCRIPTION
Implement last modification time and content length in URLConnection for SJH modular class loaders. Enables support for javacpp.

javacpp tries to extract the native DLLs it is wrapping into a cache directory. In normal operation, it retrieves the lastModifiedDate+size  from a JarURLConnection to handle conflicts. When using javacpp in Neoforge, this fails. javacpp cannot use its  JarUrlConnection special case and will fall back to using the generic URLConnection methods `getContentLength` and `getLastModified`, which  SJH does not implement. That leads to crashes (since javacpp can no longer detect if the DLL it is trying to extract is different from the one already on disk). Implementing these two methods in SJH fixes the issue.

Fixes https://github.com/bytedeco/javacpp/issues/697