### PR TITLE
Fix loading package-info classes

### DIFF
--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -172,7 +172,9 @@ public class ModuleClassLoader extends ClassLoader {
         var modroot = this.resolvedRoots.get(ref.descriptor().name());
         ProtectionDomainHelper.tryDefinePackage(this, name, modroot.jar().getManifest(), t->modroot.jar().getManifest().getAttributes(t), this::definePackage); // Packages are dirctories, and can't be signed, so use raw attributes instead of signed.
         var cs = ProtectionDomainHelper.createCodeSource(toURL(ref.location()), modroot.jar().verifyAndGetSigners(cname, bytes));
-        return defineClass(name, bytes, 0, bytes.length, ProtectionDomainHelper.createProtectionDomain(cs, this));
+        var cls = defineClass(name, bytes, 0, bytes.length, ProtectionDomainHelper.createProtectionDomain(cs, this));
+        ProtectionDomainHelper.trySetPackageModule(cls.getPackage(), cls.getModule());
+        return cls;
     }
 
     protected byte[] maybeTransformClassBytes(final byte[] bytes, final String name, final String context) {

--- a/src/test/java/cpw/mods/cl/test/TestPackageInfo.java
+++ b/src/test/java/cpw/mods/cl/test/TestPackageInfo.java
@@ -1,0 +1,22 @@
+package cpw.mods.cl.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+
+public class TestPackageInfo {
+
+    @Test
+    public void testPackageInfoAvailability() throws Exception {
+        // package-info classes can be loaded
+        TestjarUtil.withTestjar1Setup(cl -> {
+            String annotationType = "cpw.mods.cl.testjar1.TestAnnotation";
+            // Reference package through a class to ensure correct behavior of ModuleClassLoader#findClass(String,String)
+            Class<?> cls = Class.forName("cpw.mods.cl.testjar1.SomeClass", true, cl);
+            Annotation[] annotations = cls.getPackage().getDeclaredAnnotations();
+            Assertions.assertTrue(Arrays.stream(annotations).anyMatch(ann -> ann.annotationType().getName().equals(annotationType)), "Expected package to be annotated with " + annotationType);
+        });
+    }
+}

--- a/src/testjar1/java/cpw/mods/cl/testjar1/SomeClass.java
+++ b/src/testjar1/java/cpw/mods/cl/testjar1/SomeClass.java
@@ -1,0 +1,7 @@
+package cpw.mods.cl.testjar1;
+
+/**
+ * Referenced by {@code TestClassLoader}.
+ */
+public class SomeClass {
+}

--- a/src/testjar1/java/cpw/mods/cl/testjar1/TestAnnotation.java
+++ b/src/testjar1/java/cpw/mods/cl/testjar1/TestAnnotation.java
@@ -1,0 +1,11 @@
+package cpw.mods.cl.testjar1;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestAnnotation {
+}

--- a/src/testjar1/java/cpw/mods/cl/testjar1/package-info.java
+++ b/src/testjar1/java/cpw/mods/cl/testjar1/package-info.java
@@ -1,0 +1,3 @@
+@TestAnnotation
+package cpw.mods.cl.testjar1;
+


### PR DESCRIPTION
## The issue

Currently, SJH's `ModuleClassLoader` is unable to load `package-info` classes, which are placed in the unnamed module when it calls `definePackage`.

Java offers 2 ways of defining packages - one with version information and another with a module parameter, which are mutually exclusive. However, our use case requires both package versioning information and the module to be present.

`ModuleClassLoader` is designed to only load classes from named modules. When calling `Class.getPackage().getPackageInfo()`, Java will try to load the package-info class using `ClassLoader#findClass(String moduleName, String name)`, passing in `null` for the moduleName parameter as the package is placed in an unnamed module. Here, MCL expects `moduleName` to be non-null at all times. However, that is not true according to java's [documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ClassLoader.html#findResource(java.lang.String,java.lang.String)):
> **Parameters:**
moduleName - The module name; or null to find a resource in the [unnamed module](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ClassLoader.html#getUnnamedModule()) for this class loader

MCL will happily pass this parameter to `Configuration#findModule`, which expects a non-null value, resulting in a NPE.
### Steps to reproduce

1. Invoke `getPackage().getPackageInfo()` on your favourite class, which is loaded by a `ModuleClassLoader`
2. Expect a NPE

### Expected behavior

Much like other classes, `package-info` classes should be placed in named modules, too, rather than being loaded in the unnamed module.

## The solution

To make java load package-info classes in their module, we must replace the value of the `NamedPackage#module` field. Since java puts no restrictions in place that would prevent us from setting a named module on a `NamedPackage` instance, we reflectively replace the default unnamed module value with the package's actual module.

Step 1: Grab the trusted method lookup instance and create a field handle for the package module field
```java
var trustedLookupField = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");  
trustedLookupField.setAccessible(true);  
MethodHandles.Lookup trustedLookup = (MethodHandles.Lookup) trustedLookupField.get(null);  
  
Class<?> namedPackage = Class.forName("java.lang.NamedPackage");  
PKG_MODULE_HANDLE = trustedLookup.findVarHandle(namedPackage, "module", Module.class);
```

Step 2: After defining each class (necessary for the module to be known), ensure its package is placed in a named module
```java
// Get package module
Module value = (Module) PKG_MODULE_HANDLE.get(pkg);  
// Check if the value is not a named module
if (value == null || !value.isNamed()) {  
    try {
        // Replace the value with the loaded class's module
        PKG_MODULE_HANDLE.set(pkg, module);  
    } catch (Throwable t) {  
        throw new RuntimeException(t);  
    }  
}
```