### PR TITLE
Compute jar module descriptors in parallel

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -15,6 +15,17 @@ public interface JarMetadata {
     @Nullable
     String version();
     ModuleDescriptor descriptor();
+
+    /**
+     * {@return the provider declarations for this jar}
+     *
+     * <p>Computing the {@link #descriptor()} can be expensive as it requires scanning the jar for packages.
+     * If only the service providers are needed, this method can be used instead.
+     */
+    default List<SecureJar.Provider> providers() {
+        return descriptor().provides().stream().map(p -> new SecureJar.Provider(p.service(), p.providers())).toList();
+    }
+
     // ALL from jdk.internal.module.ModulePath.java
     Pattern DASH_VERSION = Pattern.compile("-([.\\d]+)");
     Pattern NON_ALPHANUM = Pattern.compile("[^A-Za-z0-9]");

--- a/src/main/java/cpw/mods/jarhandling/LazyJarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/LazyJarMetadata.java
@@ -1,0 +1,28 @@
+package cpw.mods.jarhandling;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.module.ModuleDescriptor;
+
+/**
+ * Base class for {@link JarMetadata} implementations that lazily compute their descriptor.
+ * This is recommended because descriptor computation can then run in parallel.
+ */
+public abstract class LazyJarMetadata implements JarMetadata {
+    @Nullable
+    private ModuleDescriptor descriptor;
+
+    @Override
+    public final ModuleDescriptor descriptor() {
+        if (descriptor == null) {
+            descriptor = computeDescriptor();
+        }
+        return descriptor;
+    }
+
+    /**
+     * Computes the module descriptor for this jar.
+     * This method is called at most once.
+     */
+    protected abstract ModuleDescriptor computeDescriptor();
+}

--- a/src/main/java/cpw/mods/jarhandling/NameAndVersion.java
+++ b/src/main/java/cpw/mods/jarhandling/NameAndVersion.java
@@ -1,0 +1,9 @@
+package cpw.mods.jarhandling;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Holder class for name and version of a module, used in {@link JarMetadata} computations.
+ * Unfortunately, interfaces cannot hold private records (yet?).
+ */
+record NameAndVersion(String name, @Nullable String version) {}

--- a/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
@@ -6,6 +6,7 @@ import cpw.mods.jarhandling.SecureJar;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.module.ModuleDescriptor;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -24,6 +25,7 @@ public class SimpleJarMetadata extends LazyJarMetadata implements JarMetadata {
         this.version = version;
         this.packagesSupplier = packagesSupplier;
         this.providers = providers;
+        this.providers.removeIf(p -> p.providers().isEmpty());
     }
 
     @Override
@@ -43,7 +45,12 @@ public class SimpleJarMetadata extends LazyJarMetadata implements JarMetadata {
         if (version()!=null)
             bld.version(version());
         bld.packages(packagesSupplier.get());
-        providers.stream().filter(p->!p.providers().isEmpty()).forEach(p->bld.provides(p.serviceName(), p.providers()));
+        providers.forEach(p->bld.provides(p.serviceName(), p.providers()));
         return bld.build();
+    }
+
+    @Override
+    public List<SecureJar.Provider> providers() {
+        return Collections.unmodifiableList(providers);
     }
 }

--- a/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
@@ -1,22 +1,48 @@
 package cpw.mods.jarhandling.impl;
 
 import cpw.mods.jarhandling.JarMetadata;
+import cpw.mods.jarhandling.LazyJarMetadata;
 import cpw.mods.jarhandling.SecureJar;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.module.ModuleDescriptor;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * {@link JarMetadata} implementation for a non-modular jar, turning it into an automatic module.
  */
-public record SimpleJarMetadata(String name, String version, Set<String> pkgs, List<SecureJar.Provider> providers) implements JarMetadata {
+public class SimpleJarMetadata extends LazyJarMetadata implements JarMetadata {
+    private final String name;
+    private final String version;
+    private final Supplier<Set<String>> packagesSupplier;
+    private final List<SecureJar.Provider> providers;
+
+    public SimpleJarMetadata(String name, String version, Supplier<Set<String>> packagesSupplier, List<SecureJar.Provider> providers) {
+        this.name = name;
+        this.version = version;
+        this.packagesSupplier = packagesSupplier;
+        this.providers = providers;
+    }
+
     @Override
-    public ModuleDescriptor descriptor() {
+    public String name() {
+        return name;
+    }
+
+    @Override
+    @Nullable
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public ModuleDescriptor computeDescriptor() {
         var bld = ModuleDescriptor.newAutomaticModule(name());
         if (version()!=null)
             bld.version(version());
-        bld.packages(pkgs());
+        bld.packages(packagesSupplier.get());
         providers.stream().filter(p->!p.providers().isEmpty()).forEach(p->bld.provides(p.serviceName(), p.providers()));
         return bld.build();
     }

--- a/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/SimpleJarMetadata.java
@@ -24,8 +24,7 @@ public class SimpleJarMetadata extends LazyJarMetadata implements JarMetadata {
         this.name = name;
         this.version = version;
         this.packagesSupplier = packagesSupplier;
-        this.providers = providers;
-        this.providers.removeIf(p -> p.providers().isEmpty());
+        this.providers = providers.stream().filter(p -> !p.providers().isEmpty()).toList();
     }
 
     @Override


### PR DESCRIPTION
To compute a module descriptor, we need to compute the package list, and that is often slow. So do it in parallel! (And defer computation of the module descriptor until it is actually needed).

Also added a new method to retrieve the provided services without computing the full module descriptor, for use in the `ModDirTransformerDiscoverer`.

Tested in ATM8.