### PR TITLE
Use JDK 17 as the Gradle Toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
     group 'cpw.mods'
     java {
-        toolchain.languageVersion = JavaLanguageVersion.of(16)
+        toolchain.languageVersion = JavaLanguageVersion.of(17)
         modularity.inferModulePath.set(true)
     }
     version = gradleutils.version


### PR DESCRIPTION
Use the same JDK version as in the other NeoForged projects, preventing Gradle from downloading yet another JDK 16 just for this project.