### PR TITLE
Reject invalid service files

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/impl/JarContentsImpl.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/JarContentsImpl.java
@@ -34,6 +34,7 @@ public class JarContentsImpl implements JarContents {
             .filter(fsp->fsp.getScheme().equals("union"))
             .findFirst()
             .orElseThrow(()->new IllegalStateException("Couldn't find UnionFileSystemProvider"));
+    private static final Set<String> NAUGHTY_SERVICE_FILES = Set.of("org.codehaus.groovy.runtime.ExtensionModule");
 
     final UnionFileSystem filesystem;
     // Code signing data
@@ -204,6 +205,7 @@ public class JarContentsImpl implements JarContents {
             if (Files.exists(services)) {
                 try (var walk = Files.walk(services, 1)) {
                     this.providers = walk.filter(path->!Files.isDirectory(path))
+                            .filter(path -> !NAUGHTY_SERVICE_FILES.contains(path.getFileName().toString()))
                             .map((Path path1) -> SecureJar.Provider.fromPath(path1, filesystem.getFilesystemFilter()))
                             .toList();
                 } catch (IOException e) {

--- a/src/main/java/cpw/mods/jarhandling/impl/JarContentsImpl.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/JarContentsImpl.java
@@ -202,7 +202,7 @@ public class JarContentsImpl implements JarContents {
         if (this.providers == null) {
             final var services = this.filesystem.getRoot().resolve("META-INF/services/");
             if (Files.exists(services)) {
-                try (var walk = Files.walk(services)) {
+                try (var walk = Files.walk(services, 1)) {
                     this.providers = walk.filter(path->!Files.isDirectory(path))
                             .map((Path path1) -> SecureJar.Provider.fromPath(path1, filesystem.getFilesystemFilter()))
                             .toList();


### PR DESCRIPTION
Currently, SJH throws when building a module descriptor for jars which contain files in META-INF/services which aren't valid. All this PR does is filter out these invalid files:
- I've added a set of known "naughty" service files which don't follow the format correctly - It was mentioned in Discord that certain Groovy libraries define extensions with these invalid service files so I wanted to include these too
- JLine 3.22.0 and above define a nested file in `META-INF/services/org/jline/terminal/provider/` which doesn't follow the service file format (it's in fact a properties file). This causes SJH to throw because `exec` is not within a named package, and is blocking upgrading to newer versions of JLine