### PR TITLE
Avoid slow Files#isDirectory call in testFilter

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -453,7 +453,8 @@ public class UnionFileSystem extends FileSystem {
         var sPath = path.toString();
         if (path.getFileSystem() == basePath.getFileSystem()) // Directories, zips will be different file systems.
             sPath = basePath.relativize(path).toString().replace('\\', '/');
-        if (Files.isDirectory(path))
+        var attrs = getFileAttributes(path);
+        if (attrs.isPresent() && attrs.get().isDirectory())
             sPath += '/';
         if (sPath.length() > 1 && sPath.startsWith("/"))
             sPath = sPath.substring(1);


### PR DESCRIPTION
On ZIP file systems, `Files.isDirectory` ends up being very slow if the path does not exist (similarly to `Files.exists`, which is worked around in UnionFS). We can take advantage of the existing workaround by using our `getFileAttributes` method instead, which attempts to check if the file exists using much more efficient logic.

See the profiler screenshot below for an example of the problem.

![zfas_neo](https://github.com/McModLauncher/securejarhandler/assets/42941056/f4001d99-a657-499d-8218-25e5ded84c4d)
